### PR TITLE
Rudp cleanup

### DIFF
--- a/rfm69/rfm69.c
+++ b/rfm69/rfm69.c
@@ -68,9 +68,32 @@ RFM69_RETURN rfm69_init(
     RFM69_RETURN rval = rfm69_read(*rfm, RFM69_REG_VERSION, &buf, 1);
     if (rval == RFM69_OK) {
         if (buf == 0x00 || buf == 0xFF) { rval = RFM69_INIT_TEST; }
+        // Everything is working great and we can safely
+        // set some registers to sane defaults.
+        else {
+            rfm69_data_mode_set(*rfm, RFM69_DATA_MODE_PACKET);
+
+            uint8_t dagc = 0x30;
+            rfm69_write(
+                    *rfm,
+                    RFM69_REG_TEST_DAGC,
+                    &dagc,
+                    1 
+            );
+
+            rfm69_power_level_set(*rfm, 13);
+            rfm69_rssi_threshold_set(*rfm, 0xE4);
+            rfm69_tx_start_condition_set(*rfm, RFM69_TX_FIFO_NOT_EMPTY);
+            rfm69_broadcast_address_set(*rfm, 0xFF); 
+            rfm69_address_filter_set(*rfm, RFM69_FILTER_NODE_BROADCAST);
+
+            // Set sync value (essentially functions as subnet)
+            uint8_t sync[3] = {0x01, 0x01, 0x01};
+            rfm69_sync_value_set(*rfm, sync, 3);
+        }
     }
 
-    return rfm69_power_level_set(*rfm, 13);
+    return rval;
 }
 
 // Have you tried turning it off and on again?

--- a/rfm69/rfm69.c
+++ b/rfm69/rfm69.c
@@ -460,7 +460,6 @@ RFM69_RETURN rfm69_power_level_set(Rfm69 *rfm, int8_t pa_level) {
     printf("High power: %b\n", high_power);
     // High power modules have to follow slightly different bounds
     // regarding PA_LEVEL. -2 -> 20 Dbm. 
-    // TODO: Make the levels constant
     //
     // HW and HCW modules use only the PA1 and PA2 pins
     // 

--- a/rudp/rudp.h
+++ b/rudp/rudp.h
@@ -70,10 +70,13 @@ enum FLAG {
 };
 
 
-// rfm     - pointer to Rfm69 struct
-// address - receiver node address
-// payload - data payload to be sent
-// length  - length of data payload in bytes
+// rfm          - pointer to Rfm69 struct
+// report       - returns witn info in transmission. Can be NULL
+// address      - receiver node address
+// payload      - data payload to be sent
+// payload_size - length of data payload in bytes
+// timeout      - time in ms until retrying RBT or RACK request
+// retries      - number of retries until timeout
 bool rfm69_rudp_transmit(
         Rfm69 *rfm, 
         tx_report_t *report,
@@ -82,6 +85,25 @@ bool rfm69_rudp_transmit(
         uint payload_size, 
         uint timeout,
         uint8_t retries
+);
+
+static inline void _rudp_block_until_packet_sent(Rfm69 *rfm);
+
+// rfm                - pointer to Rfm69 struct
+// address            - returns with TX address
+// payload            - void buffer to recieve payload
+// payload_size       - should be passed containing length of payload buffer (to prevent overflow)
+//                      and returns containing number of bytes actually received
+// per_packet_timeout - time in us to delay for each expected packet in data loop
+// timeout            - total time in ms until receiver times out
+bool rfm69_rudp_receive(
+        Rfm69 *rfm, 
+        rx_report_t *report,
+		uint8_t *address,
+        uint8_t *payload, 
+        uint *payload_size,
+        uint per_packet_timeout,
+        uint timeout
 );
 
 static void _rudp_init(Rfm69 *rfm);
@@ -100,22 +122,5 @@ static RUDP_RETURN _rudp_rx_rack(
 );
 
 static inline bool _rudp_is_payload_ready(Rfm69 *rfm);
-
-static inline void _rudp_block_until_packet_sent(Rfm69 *rfm);
-
-// rfm     - pointer to Rfm69 struct
-// address - returns with TX address
-// payload - void buffer to recieve payload
-// length  - should be passed containing length of payload buffer (to prevent overflow)
-//           and returns containing number of bytes actually received
-bool rfm69_rudp_receive(
-        Rfm69 *rfm, 
-        rx_report_t *report,
-		uint8_t *address,
-        uint8_t *payload, 
-        uint *payload_size,
-        uint per_packet_timeout,
-        uint timeout
-);
 
 #endif // RFM60_RUDP_H

--- a/rudp/rudp.h
+++ b/rudp/rudp.h
@@ -3,32 +3,44 @@
 
 #include "rfm69.h"
 
+typedef enum _RUDP_RETURN {
+    RUDP_OK,
+    RUDP_OK_UNCONFIRMED,
+    RUDP_TIMEOUT,
+    RUDP_BUFFER_OVERFLOW,
+    RUDP_PAYLOAD_OVERFLOW
+} RUDP_RETURN;
+
 typedef struct _tx_report {
     uint payload_size;
-    uint num_packets;
     uint packets_sent;
     uint rbt_retries;
     uint retransmissions; 
     uint racks_received;
     uint rack_requests;
-    uint return_status;
+    RUDP_RETURN return_status;
+    uint8_t tx_address;
+    uint8_t rx_address;
+    uint8_t num_packets;
 } tx_report_t;
 
-typedef enum _RUDP_RETURN {
-    RUDP_OK,
-    RUDP_OK_UNCONFIRMED,
-    RUDP_TIMEOUT,
-    RUDP_RX_BUFFER_OVERFLOW,
-    RUDP_PAYLOAD_OVERFLOW
-} RUDP_RETURN;
+typedef struct _rx_report {
+    uint bytes_expected;
+    uint bytes_received;
+    uint packets_received;
+    uint acks_sent;
+    uint racks_sent;
+    uint rack_requests;
+    RUDP_RETURN return_status;
+    uint8_t rx_address;
+    uint8_t tx_address;
+} rx_report_t;
 
-#define TX_RTP_TIMEOUT 1000 // 100ms ack timout
-#define TX_RTP_RETRIES 5
-#define TX_REQ_RACK_RETRIES 5
-
+// I might eliminate this. I don't think it is really needed.
 #define TX_INTER_PACKET_DELAY 0 
 
-#define RX_DATA_LOOP_TIME 108500
+// The constant amount of time it takes to receive one data
+
 #define _RX_DATA_TIMEOUT 12000
 #define RX_DATA_TIMEOUT (TX_INTER_PACKET_DELAY + _RX_DATA_TIMEOUT)
 #define TX_RACK_TIMEOUT 300
@@ -96,11 +108,13 @@ static inline void _rudp_block_until_packet_sent(Rfm69 *rfm);
 // payload - void buffer to recieve payload
 // length  - should be passed containing length of payload buffer (to prevent overflow)
 //           and returns containing number of bytes actually received
-RUDP_RETURN rfm69_rudp_receive(
+bool rfm69_rudp_receive(
         Rfm69 *rfm, 
+        rx_report_t *report,
 		uint8_t *address,
         uint8_t *payload, 
         uint *payload_size,
+        uint per_packet_timeout,
         uint timeout
 );
 

--- a/test/rx/test_rx.c
+++ b/test/rx/test_rx.c
@@ -58,8 +58,6 @@ int main() {
     gpio_init(PICO_DEFAULT_LED_PIN);
     gpio_set_dir(PICO_DEFAULT_LED_PIN, GPIO_OUT);
     
-    // Packet mode 
-    rfm69_data_mode_set(rfm, RFM69_DATA_MODE_PACKET);
     // 250kb/s baud rate
     rfm69_bitrate_set(rfm, RFM69_MODEM_BITRATE_57_6);
     // ~2 beta 
@@ -71,33 +69,9 @@ int main() {
     rfm69_rxbw_set(rfm, RFM69_RXBW_MANTISSA_20, 2);
     rfm69_dcfree_set(rfm, RFM69_DCFREE_WHITENING);
     // Transmit starts with any data in the FIFO
-    rfm69_tx_start_condition_set(rfm, RFM69_TX_FIFO_NOT_EMPTY);
 
-    // Set sync value (essentially functions as subnet)
-    uint8_t sync[3] = {0x01, 0x01, 0x01};
-    rfm69_sync_value_set(rfm, sync, 3);
 
     rfm69_node_address_set(rfm, 0x02); 
-    rfm69_broadcast_address_set(rfm, 0x86); 
-
-    // Set to filter by node and broadcast address
-    rfm69_address_filter_set(rfm, RFM69_FILTER_NODE_BROADCAST);
-
-    // Recommended rssi thresh default setting
-    rfm69_rssi_threshold_set(rfm, 0xE4);
-
-    //rfm69_write_masked(
-    //        rfm,
-    //        RFM69_REG_AFC_FEI,
-    //        0x08,
-    //        0x08
-    //);
-    //rfm69_write_masked(
-    //        rfm,
-    //        RFM69_REG_AFC_FEI,
-    //        0x04,
-    //        0x04
-    //);
 
     // Check if rfm69_init was successful (== 0)
     // Set last error and halt process if not.
@@ -105,37 +79,6 @@ int main() {
         set_last_error(rval); // Can use return value from rfm69_init directly
         critical_error();
     }
-
-    uint8_t dagc = 0x30;
-    rfm69_write(
-            rfm,
-            RFM69_REG_TEST_DAGC,
-            &dagc,
-            1 
-    );
-    
-
-    //rfm69_write_masked(
-    //        rfm,
-    //        RFM69_REG_AFCBW,
-    //        0x03,
-    //        0x07
-    //);
-    //
-    //rfm69_write_masked(
-    //        rfm,
-    //        RFM69_REG_AFCBW,
-    //        0x03,
-    //        0x07
-    //);
-    //
-    // LNA input impedance 200 ohms
-    //rfm69_write_masked(
-    //        rfm,
-    //        RFM69_REG_LNA,
-    //        0x80,
-    //        0x80
-    //);
 
     rfm69_power_level_set(rfm, -2);
     for(ever) { 

--- a/test/rx/test_rx.c
+++ b/test/rx/test_rx.c
@@ -24,15 +24,15 @@
 #define PIN_IRQ_1  21
 
 void set_bi() {
-    bi_decl(bi_program_name("Test Transmitter"));
-    bi_decl(bi_program_description("WISDOM sensor network basic range test rx."))
+    bi_decl(bi_program_name("Test Receiver"));
+    bi_decl(bi_program_description("WISDOM sensor network rx test."))
     bi_decl(bi_1pin_with_name(PIN_MISO, "MISO"));
     bi_decl(bi_1pin_with_name(PIN_CS, "CS"));
     bi_decl(bi_1pin_with_name(PIN_SCK, "SCK"));
     bi_decl(bi_1pin_with_name(PIN_MOSI, "MOSI"));
     bi_decl(bi_1pin_with_name(PIN_RST, "RST"));
-    bi_decl(bi_1pin_with_name(PIN_IRQ_0, "IRQ 0"));
-    bi_decl(bi_1pin_with_name(PIN_IRQ_1, "IRQ 0"));
+    //bi_decl(bi_1pin_with_name(PIN_IRQ_0, "IRQ 0"));
+    //bi_decl(bi_1pin_with_name(PIN_IRQ_1, "IRQ 1"));
 }
 
 int main() {

--- a/test/rx/test_rx.c
+++ b/test/rx/test_rx.c
@@ -81,25 +81,51 @@ int main() {
     }
 
     rfm69_power_level_set(rfm, -2);
+    rx_report_t report;
+    bool success;
     for(ever) { 
 
         uint8_t address;
         uint size = 100000;
         uint8_t payload[size];
 
-        rval = rfm69_rudp_receive(
+        printf("Waiting for message\n");
+        printf("...\n");
+
+        success = rfm69_rudp_receive(
                 rfm,
+                &report,
                 &address,
                 payload,
                 &size,
-                60000
+                12000,
+                30000
         );
 
-        if (rval == RUDP_OK) printf("RUDP_OK\n");
-        else printf("RUDP_TIMOUT\n");
+        printf("Report\n");
+        printf("------\n");
+        printf("      tx_address: %u\n", report.tx_address);
+        printf("      rx_address: %u\n", report.rx_address);
+        printf("  bytes_expected: %u\n", report.bytes_expected);
+        printf("  bytes_received: %u\n", report.bytes_received);
+        printf("packets_received: %u\n", report.packets_received);
+        printf("       acks_sent: %u\n", report.acks_sent);
+        printf("      racks_sent: %u\n", report.racks_sent);
+        printf("   rack_requests: %u\n", report.rack_requests);
 
-        printf("message: %s\n\n", payload);
-
+        switch(report.return_status) {
+            case RUDP_OK:
+                printf("   return_status: RUDP_OK\n");
+                break;
+            case RUDP_TIMEOUT:
+                printf("   return_status: RUDP_TIMEOUT\n");
+                break;
+            case RUDP_BUFFER_OVERFLOW:
+                printf("   return_status: RUDP_BUFFER_OVERFLOW\n");
+                break;
+        }
+        printf("         message: %s\n", payload);
+        printf("\n");
     }
     
     return 0;

--- a/test/tx/test_tx.c
+++ b/test/tx/test_tx.c
@@ -25,14 +25,14 @@
 
 void set_bi() {
     bi_decl(bi_program_name("Test Transmitter"));
-    bi_decl(bi_program_description("WISDOM sensor network basic range test tx."))
+    bi_decl(bi_program_description("WISDOM sensor network tx test."))
     bi_decl(bi_1pin_with_name(PIN_MISO, "MISO"));
     bi_decl(bi_1pin_with_name(PIN_CS, "CS"));
     bi_decl(bi_1pin_with_name(PIN_SCK, "SCK"));
     bi_decl(bi_1pin_with_name(PIN_MOSI, "MOSI"));
     bi_decl(bi_1pin_with_name(PIN_RST, "RST"));
-    bi_decl(bi_1pin_with_name(PIN_IRQ_0, "IRQ 0"));
-    bi_decl(bi_1pin_with_name(PIN_IRQ_1, "IRQ 1"));
+    //bi_decl(bi_1pin_with_name(PIN_IRQ_0, "IRQ 0"));
+    //bi_decl(bi_1pin_with_name(PIN_IRQ_1, "IRQ 1"));
 }
 
 int main() {
@@ -78,21 +78,6 @@ int main() {
         set_last_error(rval); // Can use return value from rfm69_init directly
         critical_error();
     }
-
-    //rfm69_write_masked(
-    //        rfm,
-    //        RFM69_REG_AFCBW,
-    //        0x03,
-    //        0x07
-    //);
-
-    // LNA input impedance 200 ohms
-    //rfm69_write_masked(
-    //        rfm,
-    //        RFM69_REG_LNA,
-    //        0x80,
-    //        0x80
-    //);
 
     rfm69_power_level_set(rfm, -2);
     bool success;

--- a/test/tx/test_tx.c
+++ b/test/tx/test_tx.c
@@ -89,36 +89,48 @@ int main() {
         //uint buf_size = get_rand_32() % 10000;
         //uint buf_size = TX_PACKETS_MAX * PAYLOAD_MAX;
         //uint buf_size = PAYLOAD_MAX;
-        printf("Sending transmission...\n");
-        printf("buf_size: %u\n", buf_size);
+        printf("Sending message: %s\n", message);
+        printf("...\n");
+
+        uint8_t buf[buf_size];
+        for (int i = 0; i < buf_size; i++) {
+            buf[i] = get_rand_32() % 256;
+        }
 
         success = rfm69_rudp_transmit(
                 rfm,
                 &report,
                 0x02,
                 message,
+                //buf,
                 buf_size,
                 300,
                 5 
         );
 
-        printf("tx_report:\n");
-        printf("payload_size:\t%u\n", report.payload_size);
-        printf("num_packets:\t%u\n", report.num_packets);
-        printf("packets_sent:\t%u\n", report.packets_sent);
-        printf("rbt_retries:\t%u\n", report.rbt_retries);
-        printf("retransmissions:%u\n", report.retransmissions);
-        printf("racks_received:\t%u\n", report.racks_received);
-        printf("rack_requests:\t%u\n", report.rack_requests);
+        printf("Report\n");
+        printf("------\n");
+        printf("     tx_address: %u\n", report.tx_address);
+        printf("     rx_address: %u\n", report.rx_address);
+        printf("   payload_size: %u\n", report.payload_size);
+        printf("    num_packets: %u\n", report.num_packets);
+        printf("   packets_sent: %u\n", report.packets_sent);
+        printf("    rbt_retries: %u\n", report.rbt_retries);
+        printf("retransmissions: %u\n", report.retransmissions);
+        printf(" racks_received: %u\n", report.racks_received);
+        printf("  rack_requests: %u\n", report.rack_requests);
         switch(report.return_status) {
             case RUDP_OK:
-                printf("return_status:\tRUDP_OK\n");
+                printf("  return_status: RUDP_OK\n");
                 break;
             case RUDP_OK_UNCONFIRMED:
-                printf("return_status:\tRUDP_OK_UNCONFIRMED\n");
+                printf("  return_status: RUDP_OK_UNCONFIRMED\n");
                 break;
             case RUDP_TIMEOUT:
-                printf("return_status:\tRUDP_TIMEOUT\n");
+                printf("  return_status: RUDP_TIMEOUT\n");
+                break;
+            case RUDP_PAYLOAD_OVERFLOW:
+                printf("  return_status: RUDP_PAYLOAD_OVERFLOW\n");
                 break;
         }
         printf("\n");

--- a/test/tx/test_tx.c
+++ b/test/tx/test_tx.c
@@ -58,10 +58,6 @@ int main() {
     gpio_init(PICO_DEFAULT_LED_PIN);
     gpio_set_dir(PICO_DEFAULT_LED_PIN, GPIO_OUT);
     
-    //rfm69_mode_set(rfm, RFM69_OP_MODE_SLEEP);
-
-    // Packet mode 
-    rfm69_data_mode_set(rfm, RFM69_DATA_MODE_PACKET);
     // 250kb/s baud rate
     rfm69_bitrate_set(rfm, RFM69_MODEM_BITRATE_57_6);
     // ~2 beta 
@@ -73,34 +69,8 @@ int main() {
     rfm69_rxbw_set(rfm, RFM69_RXBW_MANTISSA_20, 2);
     rfm69_dcfree_set(rfm, RFM69_DCFREE_WHITENING);
     // Transmit starts with any data in the FIFO
-    rfm69_tx_start_condition_set(rfm, RFM69_TX_FIFO_NOT_EMPTY);
-
-    // Set sync value (essentially functions as subnet)
-    uint8_t sync[3] = {0x01, 0x01, 0x01};
-    rfm69_sync_value_set(rfm, sync, 3);
 
     rfm69_node_address_set(rfm, 0x01); 
-    rfm69_broadcast_address_set(rfm, 0x86); 
-
-    // Set to filter by node and broadcast address
-    rfm69_address_filter_set(rfm, RFM69_FILTER_NODE_BROADCAST);
-
-    // Recommended rssi thresh default setting
-    rfm69_rssi_threshold_set(rfm, 0xE4);
-
-    //rfm69_write_masked(
-    //        rfm,
-    //        RFM69_REG_AFC_FEI,
-    //        0x08,
-    //        0x08
-    //);
-    //rfm69_write_masked(
-    //        rfm,
-    //        RFM69_REG_AFC_FEI,
-    //        0x04,
-    //        0x04
-    //);
-
 
     // Check if rfm69_init was successful (== 0)
     // Set last error and halt process if not.
@@ -109,14 +79,6 @@ int main() {
         critical_error();
     }
 
-    uint8_t dagc = 0x30;
-    rfm69_write(
-            rfm,
-            RFM69_REG_TEST_DAGC,
-            &dagc,
-            1 
-    );
-    
     //rfm69_write_masked(
     //        rfm,
     //        RFM69_REG_AFCBW,

--- a/test/tx/test_tx.c
+++ b/test/tx/test_tx.c
@@ -84,7 +84,7 @@ int main() {
     tx_report_t report;
     for(ever) { 
 
-        char *message = "Hello, world!";
+        char *message = "Hello, campers!";
         uint buf_size = strlen(message) + 1;
         //uint buf_size = get_rand_32() % 10000;
         //uint buf_size = TX_PACKETS_MAX * PAYLOAD_MAX;


### PR DESCRIPTION
Cleaned up RUDP functions by simplifying the return to a bool to signal success, and the two interface functions now each take a specific struct (rx_report_t and tx_report_t) which logs information about the transaction. If this information is not wanted and a success/fail is enough, NULL can be passed in the place of a report struct.

Minimum documentation has been added to the interface, and I would like to come back to this later, but this is enough for now.

This closes up the 1.0 development of the RUDP protocol.